### PR TITLE
Allow support for Laravel Passport 7.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 		"php": "^7.0",
 		"guzzlehttp/guzzle": "~6.0",
 		"ipunkt/laravel-package-manager": "^1.0",
-		"laravel/passport": "~1.0|~2.0|~3.0|~4.0|~5.0|~6.0"
+		"laravel/passport": "~1.0|~2.0|~3.0|~4.0|~5.0|~6.0|~7.0"
 	},
 	"autoload": {
 		"psr-4": {


### PR DESCRIPTION
This PR adds support for Laravel Passport v7, which is default in Laravel 5.7.