### PR TITLE
Replaced hard coded user model reference with UserProvider

### DIFF
--- a/src/Providers/OAuthIntrospectionServiceProvider.php
+++ b/src/Providers/OAuthIntrospectionServiceProvider.php
@@ -2,11 +2,30 @@
 
 namespace Ipunkt\Laravel\OAuthIntrospection\Providers;
 
+use Illuminate\Contracts\Auth\UserProvider;
 use Illuminate\Support\AggregateServiceProvider;
+use Illuminate\Support\Facades\Auth;
+use Ipunkt\Laravel\OAuthIntrospection\Http\Controllers\IntrospectionController;
 
 class OAuthIntrospectionServiceProvider extends AggregateServiceProvider
 {
 	protected $providers = [
 		RouteProvider::class,
 	];
+
+    /**
+     * Register the service provider.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        parent::register();
+
+        $this->app->when(IntrospectionController::class)
+            ->needs(UserProvider::class)
+            ->give(function(){
+                return Auth::createUserProvider();
+            });
+    }
 }

--- a/src/Providers/RouteProvider.php
+++ b/src/Providers/RouteProvider.php
@@ -8,7 +8,7 @@ class RouteProvider extends RouteServiceProvider
 {
 	protected $packagePath = __DIR__ . '/../../';
 
-	protected $routesNamespace = '\Ipunkt\Laravel\OAuthIntrospection\Http\Controllers';
+	protected $routesNamespace = 'Ipunkt\Laravel\OAuthIntrospection\Http\Controllers';
 
 	protected $routesMiddleware = null;
 


### PR DESCRIPTION
Fixes issue #8 

To customize the UserProvider you can add the following binding into your own service provider:

```
$this->app->when(IntrospectionController::class)
    ->needs(UserProvider::class)
    ->give(function(){
        return new MyUserProvider();
    });
```